### PR TITLE
Added parse block and span false flag to config on advice of github c…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -219,6 +219,8 @@ kramdown:
   toc_levels: 1..6
   smart_quotes: lsquo,rsquo,ldquo,rdquo
   enable_coderay: false
+  parse_block_html: false
+  parse_span_html: false
 
 
 # Sass/SCSS


### PR DESCRIPTION
…opilot to prevent parsing of HTLM/Liquid in block-level elements